### PR TITLE
Parse locale specs with underscores

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ limitations under the License.
 
 # Release Notes
 
+## v1.1.0
+
+- added the ability to parse locale specs that contain underscores
+  instead of dashes. Some locale specs for Java properties file names
+  or in some gnu gettext libraries are specified with underscores.
+  (ie. "zh_Hans_CN" === "zh-Hans-CN" now)
+- updated dependencies
+
 ## v1.0.2
 
 - fixed some incorrect unit tests

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-locale",
-    "version": "1.0.2",
+    "version": "1.1.0",
     "main": "./lib/Locale.js",
     "description": "A BCP-47/IETF locale specifier parser/validator",
     "keywords": [
@@ -66,19 +66,19 @@
         "doc:html": "jsdoc -c jsdoc.json"
     },
     "devDependencies": {
-        "@babel/core": "^7.14.3",
-        "@babel/preset-env": "^7.14.2",
-        "@babel/register": "^7.13.16",
-        "@babel/runtime": "^7.14.0",
+        "@babel/core": "^7.15.5",
+        "@babel/preset-env": "^7.15.6",
+        "@babel/register": "^7.15.3",
+        "@babel/runtime": "^7.15.4",
         "acorn": "^6.4.1",
-        "acorn-jsx": "^5.2.0",
+        "acorn-jsx": "^5.3.2",
         "assertextras": "^1.1.0",
         "babel-loader": "^8.2.2",
         "babel-plugin-add-module-exports": "^1.0.4",
         "docdash": "^1.2.0",
-        "grunt": "^1.4.0",
+        "grunt": "^1.4.1",
         "grunt-babel": "^8.0.0",
-        "grunt-cli": "^1.3.2",
+        "grunt-cli": "^1.4.3",
         "grunt-contrib-clean": "^2.0.0",
         "grunt-contrib-jshint": "^2.1.0",
         "grunt-contrib-nodeunit": "^2.1.0",
@@ -88,10 +88,10 @@
         "load-grunt-tasks": "^5.1.0",
         "nodeunit": "^0.11.3",
         "open-cli": "^6.0.1",
-        "webpack": "^5.37.1",
-        "webpack-cli": "^4.7.0"
+        "webpack": "^5.53.0",
+        "webpack-cli": "^4.8.0"
     },
     "dependencies": {
-        "ilib-env": "^1.0.0"
+        "ilib-env": "^1.0.1"
     }
 }

--- a/src/Locale.js
+++ b/src/Locale.js
@@ -112,7 +112,7 @@ class Locale {
         if (typeof(region) === 'undefined' && typeof(variant) === 'undefined' && typeof(script) === 'undefined') {
             let spec = language || ilibEnv.getLocale();
             if (typeof(spec) === 'string') {
-                const parts = spec.split('-');
+                const parts = spec.split(/[-_]/g);
                 for (let i = 0; i < parts.length; i++ ) {
                     if (Locale._isLanguageCode(parts[i])) {
                         /**

--- a/test/testlocale.js
+++ b/test/testlocale.js
@@ -359,6 +359,35 @@ module.exports.testlocale = {
         test.done();
     },
 
+    testLocaleConstructorSpecWithUnderscores1: function(test) {
+        test.expect(5);
+        // some locales like those in java properties file names
+        // or in gnu gettext libraries are specified with underscores
+        var loc = new Locale("zh_Hans_CN");
+
+        test.ok(loc !== null);
+
+        test.equal(loc.getLanguage(), "zh");
+        test.equal(loc.getRegion(), "CN");
+        test.equal(loc.getScript(), "Hans");
+        test.ok(typeof(loc.getVariant()) === "undefined");
+        test.done();
+    },
+
+    testLocaleConstructorSpecWithUnderscores2: function(test) {
+        test.expect(4);
+        // some locales like those in java properties file names
+        // or in gnu gettext libraries are specified with underscores
+        var loc = new Locale("en_US");
+
+        test.ok(loc !== null);
+
+        test.equal(loc.getLanguage(), "en");
+        test.equal(loc.getRegion(), "US");
+        test.ok(typeof(loc.getVariant()) === "undefined");
+        test.done();
+    },
+
     testLocaleConstructorShort: function(test) {
         test.expect(4);
         var loc = new Locale("en");


### PR DESCRIPTION
- added the ability to parse locale specs that contain underscores instead of dashes. Some locale specs for Java properties file names or in some gnu gettext libraries are specified with underscores. (ie. "zh_Hans_CN" === "zh-Hans-CN" now)
- updated dependencies